### PR TITLE
ci: add workflow for building pdfs

### DIFF
--- a/.github/workflows/build-pdfs.yaml
+++ b/.github/workflows/build-pdfs.yaml
@@ -1,0 +1,32 @@
+name: build documents
+on:
+  push:
+    branches: main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: get images
+        run: |
+          ./download-images.sh
+
+      # is it even necessary to use an action for this?
+      - name: build pdfs
+        uses: lvignoli/typst-action@main
+        with:
+          source_file: |
+            chap1.typ
+            chap2.typ
+            chap3.typ
+            chap4.typ
+
+      - name: upload pdfs
+        uses: actions/upload-artifact@v4
+        # always upload, even if building fails
+        if: "success() || failure()"
+        with:
+          name: promi-pdfs
+          path: "*.pdf"

--- a/Image Sources.md
+++ b/Image Sources.md
@@ -1,5 +1,0 @@
-# Bildquellen
-
-## Chapter 4
-
-- [lambda_complexity.png](https://stats.stackexchange.com/questions/118712/why-does-ridge-estimate-become-better-than-ols-by-adding-a-constant-to-the-diago) <br> bzw. [direkt](https://i.sstatic.net/1d8XV.png)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Vorlesungsinhalte des Moduls ProMI (Probabilistische Methoden der Informatik) au
 
 In Zukunft sollen die Kapitel auch noch mit Graphen ergänzt und weiter verdeutlicht werden. Da Typst meines erachtens aktuell keine ordentlichen packages für Graphen hat wird sich hier wahrscheinlich eher die Generierung via Python und matplotlib eignen.
 
+#### Vorgebaute PDFs
+
+Mit jedem Commit auf `main` werden automatisch PDFs gebaut, diese sind bei den [Action-Runs](https://github.com/fussballandy/promi-2425/actions) zu finden. Einfach auf den letzten Run clicken und die Artefakte herunterladen, in der Zip-Datei sind die Dokumente.
+
+> [!WARNING]
+> Kapitel 2 baut aktuell aufgrund einer Regression in `fletcher` nicht, wenn man typst `0.13.0-rc1` oder neuer verwendet und ist somit in der CI aktuell nicht verfügbar und die Runs schlagen fehl. Die anderen Kapitel sind jedoch verfügbar.
+
+
 #### Hinweise
 
 Der Titel "Probabilistischer Untergang meines Lebens" ist rein humorvoll aufzufassen.
+
+#### Bauen
+
+Um eventuell benötigte Bilder in das `images/`-Verzeichnis herunterzuladen, kann das Skript [`download-images.sh`](download-images.sh) genutzt werden.
+Die Bilder sind in der Datei [`image-sources.txt`](image-sources.txt) festgehalten, nach folgendem Schema:
+```
+<dateiname> <quell-url, die direkt zur datei führt> <weitere kommentare (optional)>
+```

--- a/download-images.sh
+++ b/download-images.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+mkdir -p ./images
+xargs -P 10 -a image-sources.txt -L1 bash -c 'wget -t 10 $1 -O images/$0'

--- a/image-sources.txt
+++ b/image-sources.txt
@@ -1,0 +1,1 @@
+lambda_complexity.png https://i.sstatic.net/1d8XV.png https://stats.stackexchange.com/questions/118712/why-does-ridge-estimate-become-better-than-ols-by-adding-a-constant-to-the-diago


### PR DESCRIPTION
building of `chap2` fails, presumably due to Jollywatt/typst-fletcher#75, this is noted in the readme and will probably be fixed by a dependency update soon
the other files build without issues
- add ci job for buildind the pdfs, uploading them as artifacts
  - the workflow is executed on push to `main`. this should include pr merges
- add script for downloading the images to build the pdfs
- rework image-sources file to make it easier to parse for the script
- add documentation