### PR TITLE
 ci: switch typst action 

### DIFF
--- a/.github/workflows/build-pdfs.yaml
+++ b/.github/workflows/build-pdfs.yaml
@@ -8,20 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: typst-community/setup-typst@v4
 
       - name: get images
         run: |
           ./download-images.sh
 
-      # is it even necessary to use an action for this?
       - name: build pdfs
-        uses: lvignoli/typst-action@main
-        with:
-          source_file: |
-            chap1.typ
-            chap2.typ
-            chap3.typ
-            chap4.typ
+        run: |
+          typst c chap1.typ
+          typst c chap2.typ
+          typst c chap3.typ
+          typst c chap4.typ
 
       - name: upload pdfs
         uses: actions/upload-artifact@v4

--- a/template.typ
+++ b/template.typ
@@ -26,7 +26,7 @@
   )
 
   set par(justify: true)
-  set text(font: "Arial", size: 10pt, lang: "de")
+  set text(font: "New Computer Modern", size: 10pt, lang: "de")
   show math.equation: set text(font: "New Computer Modern Math", size: 1.1em)
   set list(marker: [--])
 


### PR DESCRIPTION
- switch font as discussed
- doesn't use a pre-release so everything compiles
- is faster (i think, doesn't really matter)

run using this commit: https://github.com/w-lfchen/promi-2425/actions/runs/13262945902/job/37023485713
(ignore my fork's main branch, it's a mess for testing)